### PR TITLE
fix subdirectory processing order for static builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,10 +391,11 @@ add_definitions(-DVSXU_INSTALL_LIB_DIR="${VSXU_INSTALL_LIB_DIR}")
 ################################################################################
 # VSXU LIBRARIES ###############################################################
 ################################################################################
-add_subdirectory(engine)
 add_subdirectory(engine_audiovisual)
 add_subdirectory(engine_graphics)
+# order matters - need to add plugins before engine to create static glue
 add_subdirectory(plugins)
+add_subdirectory(engine)
 add_subdirectory(widget)
 
 ################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,27 +56,6 @@ if (UNIX OR VSXU_WINDOWS_LIB_BUILD)
 endif()
 
 ################################################################################
-# The pkg-config file
-################################################################################
-IF (UNIX OR VSXU_WINDOWS_LIB_BUILD)
-  if (VSXU_STATIC EQUAL 1 AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/plugins/static_factory_pkgconfig_libs")
-    file (STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/plugins/static_factory_pkgconfig_libs" VSXU_PLUGIN_PKGCONFIG_LIBS)
-    CONFIGURE_FILE (${CMAKE_CURRENT_SOURCE_DIR}/libvsxu.pc.in.static
-                    ${CMAKE_CURRENT_BINARY_DIR}/libvsxu.pc
-                    @ONLY)
-
-  else()
-    CONFIGURE_FILE (${CMAKE_CURRENT_SOURCE_DIR}/libvsxu.pc.in.dynamic
-                    ${CMAKE_CURRENT_BINARY_DIR}/libvsxu.pc
-                    @ONLY)
-  endif()
-
-  INSTALL (FILES ${CMAKE_CURRENT_BINARY_DIR}/libvsxu.pc
-           DESTINATION ${VSXU_INSTALL_LIB_DIR}/pkgconfig)
-ENDIF()
-
-
-################################################################################
 # CPACK OPTIONS ################################################################
 ################################################################################
 SET(CPACK_PACKAGE_NAME "vsxu")
@@ -420,8 +399,25 @@ if(UNIX)
     add_subdirectory(tools/vsxl)
 endif(UNIX)
 
+################################################################################
+# The pkg-config file
+################################################################################
+IF (UNIX OR VSXU_WINDOWS_LIB_BUILD)
+  if (VSXU_STATIC EQUAL 1 AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/plugins/static_factory_pkgconfig_libs")
+    file (STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/plugins/static_factory_pkgconfig_libs" VSXU_PLUGIN_PKGCONFIG_LIBS)
+    CONFIGURE_FILE (${CMAKE_CURRENT_SOURCE_DIR}/libvsxu.pc.in.static
+                    ${CMAKE_CURRENT_BINARY_DIR}/libvsxu.pc
+                    @ONLY)
 
+  else()
+    CONFIGURE_FILE (${CMAKE_CURRENT_SOURCE_DIR}/libvsxu.pc.in.dynamic
+                    ${CMAKE_CURRENT_BINARY_DIR}/libvsxu.pc
+                    @ONLY)
+  endif()
 
+  INSTALL (FILES ${CMAKE_CURRENT_BINARY_DIR}/libvsxu.pc
+           DESTINATION ${VSXU_INSTALL_LIB_DIR}/pkgconfig)
+ENDIF()
 
 # uninstall target
 configure_file(


### PR DESCRIPTION
The 'engine' buildsystem tries to include a file created by the 'plugins' buildsystem when using VSXU_STATIC