### PR TITLE
Fix init and uninit function names in server application

### DIFF
--- a/programs/server/src/server_application.h
+++ b/programs/server/src/server_application.h
@@ -57,7 +57,7 @@ public:
     return vsx_string<>(titlestr);
   }
 
-  void init()
+  void init_graphics()
   {
     module_list = vsx_module_list_factory_create();
     vxe = new vsx_engine(module_list);
@@ -66,7 +66,7 @@ public:
     cl_server.start();
   }
 
-  void uninit()
+  void uninit_graphics()
   {
     vxe->stop();
     delete vxe;


### PR DESCRIPTION
In commit d5d3d1cb9, the init and uninit functions of the applications
were renamed to init_graphics and uninit_graphics but
server_application.h was skipped. This caused a segmentation fault when
executing the server because vxe was uninitialized.