### PR TITLE
add .vscode/ and .DS_Store/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,6 +240,9 @@ UpgradeLog*.htm
 *.bim.layout
 *.bim_*.settings
 
+# Mac OS folder attributes folder
+.DS_Store/
+
 # Microsoft Fakes
 FakesAssemblies/
 
@@ -262,6 +265,9 @@ FakesAssemblies/
 **/*.Server/GeneratedArtifacts
 **/*.Server/ModelManifest.xml
 _Pvt_Extensions
+
+# Visual Studio Code Text Editor Files
+.vscode/
 
 # Paket dependency manager
 .paket/paket.exe


### PR DESCRIPTION
.vscode and .DS_Store are not project-affecting files and are only meant for the developer's local system.  Thus, they should be ignored.

.DS_Store is a file that stores custom attributes of its containing folder for Mac OS.
.vscode is a storage folder for Visual Studio Code Text Editor data.